### PR TITLE
Add flag to display unique color for every MonitorId.

### DIFF
--- a/CK.Monitoring/ConsoleExtensions.cs
+++ b/CK.Monitoring/ConsoleExtensions.cs
@@ -1,0 +1,213 @@
+//From: https://github.com/silkfire/Pastel
+namespace Pastel
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Drawing;
+    using System.Globalization;
+    using System.Linq;
+    using System.Runtime.InteropServices;
+    using System.Text.RegularExpressions;
+
+
+    /// <summary>
+    /// Controls colored console output by <see langword="Pastel"/>.
+    /// </summary>
+    public static class ConsoleExtensions
+    {
+        private const int  STD_OUTPUT_HANDLE                     = -11;
+        private const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
+
+        [DllImport("kernel32.dll")]
+        private static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+
+        [DllImport("kernel32.dll")]
+        private static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr GetStdHandle(int nStdHandle);
+
+
+        private static bool _enabled;
+
+        private delegate string ColorFormat(   string input, Color     color);
+        private delegate string HexColorFormat(string input, string hexColor);
+
+        private enum ColorPlane : byte
+        {
+            Foreground,
+            Background
+        }
+
+        private const string           _formatStringStart   = "\u001b[{0};2;";
+        private const string           _formatStringColor   = "{1};{2};{3}m";
+        private const string           _formatStringContent = "{4}";
+        private const string           _formatStringEnd     = "\u001b[0m";
+        private static readonly string _formatStringFull    = $"{_formatStringStart}{_formatStringColor}{_formatStringContent}{_formatStringEnd}";
+
+
+        private static readonly Dictionary<ColorPlane, string> _planeFormatModifiers = new Dictionary<ColorPlane, string>
+        {
+            [ColorPlane.Foreground] = "38",
+            [ColorPlane.Background] = "48"
+        };
+
+
+
+        private static readonly Regex  _closeNestedPastelStringRegex1 = new Regex($"({_formatStringEnd.Replace("[", @"\[")})+");
+        private static readonly Regex  _closeNestedPastelStringRegex2 = new Regex($"(?<!^)(?<!{_formatStringEnd.Replace("[", @"\[")})(?<!{string.Format($"{_formatStringStart.Replace("[", @"\[")}{_formatStringColor}", new[] { $"(?:{_planeFormatModifiers[ColorPlane.Foreground]}|{_planeFormatModifiers[ColorPlane.Background]})" }.Concat(Enumerable.Repeat(@"\d{1,3}", 3)).Cast<object>().ToArray())})({string.Format(_formatStringStart.Replace("[", @"\["), $"(?:{_planeFormatModifiers[ColorPlane.Foreground]}|{_planeFormatModifiers[ColorPlane.Background]})")})");
+
+        private static readonly Dictionary<ColorPlane, Regex> _closeNestedPastelStringRegex3 = new Dictionary<ColorPlane, Regex>
+        {
+            [ColorPlane.Foreground] = new Regex($"({_formatStringEnd.Replace("[", @"\[")})(?!{string.Format(_formatStringStart.Replace("[", @"\["), _planeFormatModifiers[ColorPlane.Foreground])})(?!$)"),
+            [ColorPlane.Background] = new Regex($"({_formatStringEnd.Replace("[", @"\[")})(?!{string.Format(_formatStringStart.Replace("[", @"\["), _planeFormatModifiers[ColorPlane.Background])})(?!$)")
+        };
+
+
+
+
+        private static readonly Func<string, int> _parseHexColor = hc => int.Parse(hc.Replace("#", ""), NumberStyles.HexNumber);
+
+        private static readonly Func<string,  Color, ColorPlane, string> _colorFormat    = (i, c, p) => string.Format(_formatStringFull, _planeFormatModifiers[p], c.R, c.G, c.B, CloseNestedPastelStrings(i, c, p));
+        private static readonly Func<string, string, ColorPlane, string> _colorHexFormat = (i, c, p) => _colorFormat(i, Color.FromArgb(_parseHexColor(c)), p);
+
+        private static readonly ColorFormat    _noColorOutputFormat    = (i, _) => i;
+        private static readonly HexColorFormat _noHexColorOutputFormat = (i, _) => i;
+
+        private static readonly ColorFormat    _foregroundColorFormat    = (i, c) => _colorFormat(   i, c, ColorPlane.Foreground);
+        private static readonly HexColorFormat _foregroundHexColorFormat = (i, c) => _colorHexFormat(i, c, ColorPlane.Foreground);
+
+        private static readonly ColorFormat    _backgroundColorFormat    = (i, c) => _colorFormat(   i, c, ColorPlane.Background);
+        private static readonly HexColorFormat _backgroundHexColorFormat = (i, c) => _colorHexFormat(i, c, ColorPlane.Background);
+
+
+
+        private static readonly Dictionary<bool, Dictionary<ColorPlane, ColorFormat>>       _colorFormatFuncs = new Dictionary<bool, Dictionary<ColorPlane, ColorFormat>>
+        {
+            [false] = new Dictionary<ColorPlane, ColorFormat>
+            {
+                [ColorPlane.Foreground] = _noColorOutputFormat,
+                [ColorPlane.Background] = _noColorOutputFormat
+            },
+            [true]  = new Dictionary<ColorPlane, ColorFormat>
+            {
+                [ColorPlane.Foreground] = _foregroundColorFormat,
+                [ColorPlane.Background] = _backgroundColorFormat
+            }
+        };
+        private static readonly Dictionary<bool, Dictionary<ColorPlane, HexColorFormat>> _hexColorFormatFuncs = new Dictionary<bool, Dictionary<ColorPlane, HexColorFormat>>
+        {
+            [false] = new Dictionary<ColorPlane, HexColorFormat>
+            {
+                [ColorPlane.Foreground] = _noHexColorOutputFormat,
+                [ColorPlane.Background] = _noHexColorOutputFormat
+            },
+            [true]  = new Dictionary<ColorPlane, HexColorFormat>
+            {
+                [ColorPlane.Foreground] = _foregroundHexColorFormat,
+                [ColorPlane.Background] = _backgroundHexColorFormat
+            }
+        };
+
+        
+
+
+        static ConsoleExtensions()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var iStdOut =   GetStdHandle(STD_OUTPUT_HANDLE);
+
+                var enable  =   GetConsoleMode(iStdOut, out var outConsoleMode)
+                             && SetConsoleMode(iStdOut, outConsoleMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+            }
+
+
+            if (Environment.GetEnvironmentVariable("NO_COLOR") == null)
+            {
+                Enable();
+            }
+            else
+            {
+                Disable();
+            }
+        }
+
+
+        
+
+
+
+
+        /// <summary>
+        /// Enables any future console color output produced by Pastel.
+        /// </summary>
+        public static void Enable()
+        {
+            _enabled = true;
+        }
+
+        /// <summary>
+        /// Disables any future console color output produced by Pastel.
+        /// </summary>
+        public static void Disable()
+        {
+            _enabled = false;
+        }
+
+
+        /// <summary>
+        /// Returns a string wrapped in an ANSI foreground color code using the specified color.
+        /// </summary>
+        /// <param name="input">The string to color.</param>
+        /// <param name="color">The color to use on the specified string.</param>
+        public static string Pastel(this string input, Color color)
+        {
+            return _colorFormatFuncs[_enabled][ColorPlane.Foreground](input, color);
+        }
+
+        /// <summary>
+        /// Returns a string wrapped in an ANSI foreground color code using the specified color.
+        /// </summary>
+        /// <param name="input">The string to color.</param>
+        /// <param name="hexColor">The color to use on the specified string.<para>Supported format: [#]RRGGBB.</para></param>
+        public static string Pastel(this string input, string hexColor)
+        {
+            return _hexColorFormatFuncs[_enabled][ColorPlane.Foreground](input, hexColor);
+        }
+
+
+
+        /// <summary>
+        /// Returns a string wrapped in an ANSI background color code using the specified color.
+        /// </summary>
+        /// <param name="input">The string to color.</param>
+        /// <param name="color">The color to use on the specified string.</param>
+        public static string PastelBg(this string input, Color color)
+        {
+            return _colorFormatFuncs[_enabled][ColorPlane.Background](input, color);
+        }
+
+        /// <summary>
+        /// Returns a string wrapped in an ANSI background color code using the specified color.
+        /// </summary>
+        /// <param name="input">The string to color.</param>
+        /// <param name="hexColor">The color to use on the specified string.<para>Supported format: [#]RRGGBB.</para></param>
+        public static string PastelBg(this string input, string hexColor)
+        {
+            return _hexColorFormatFuncs[_enabled][ColorPlane.Background](input, hexColor);
+        }
+
+
+
+        private static string CloseNestedPastelStrings(string input, Color color, ColorPlane colorPlane)
+        {
+            var closedString = _closeNestedPastelStringRegex1.Replace(input, _formatStringEnd);
+
+                closedString = _closeNestedPastelStringRegex2.Replace(closedString, $"{_formatStringEnd}$1");
+                closedString = _closeNestedPastelStringRegex3[colorPlane].Replace(closedString, $"$1{string.Format($"{_formatStringStart}{_formatStringColor}", _planeFormatModifiers[colorPlane], color.R, color.G, color.B)}");
+
+            return closedString;
+        }
+    }
+}

--- a/CK.Monitoring/Handlers/Console.cs
+++ b/CK.Monitoring/Handlers/Console.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Drawing;
 using CK.Core;
+using Pastel;
+
 namespace CK.Monitoring.Handlers
 {
     /// <summary>
@@ -72,11 +75,43 @@ namespace CK.Monitoring.Handlers
             var entry = _builder.FormatEntry( e.Entry );
             if( entry.Key != null )
             {
-                DisplayFormattedEntry( entry.Key.Value, LogLevel.Info);
+                DisplayFormattedEntry( entry.Key.Value, LogLevel.Info );
             }
             DisplayFormattedEntry( entry.Value, e.Entry.LogLevel );
         }
 
+        static readonly Color[] _colors = new Color[] { //handpicked
+                Color.FromArgb( 0x00, 0x00, 0xD5 ), Color.FromArgb( 0xD5, 0xB5, 0x00 ), Color.FromArgb( 0xD5, 0x20, 0x00 ), Color.FromArgb( 0x00, 0xD5, 0x95 ),
+                Color.FromArgb( 0xD5, 0x00, 0x9F ), Color.FromArgb( 0x85, 0x00, 0xD5 ), Color.FromArgb( 0xD5, 0x95, 0x00 ), Color.FromArgb( 0x00, 0xD5, 0x1B ),
+                Color.FromArgb( 0x00, 0x95, 0xD5 ), Color.FromArgb( 0x9F, 0x00, 0xD5 ), Color.FromArgb( 0xCA, 0xD5, 0x00 ), Color.FromArgb( 0x40, 0x00, 0xD5 ),
+                Color.FromArgb( 0xD5, 0x6A, 0x00 ), Color.FromArgb( 0xD5, 0x00, 0x2B ), Color.FromArgb( 0x00, 0xD5, 0xD5 ), Color.FromArgb( 0x6A, 0x00, 0xD5 ),
+
+                Color.FromArgb( 0x50, 0x50, 0x85 ), Color.FromArgb( 0x85, 0x7D, 0x50 ), Color.FromArgb( 0x85, 0x58, 0x50 ), Color.FromArgb( 0x50, 0x85, 0x75 ),
+                Color.FromArgb( 0x85, 0x50, 0x78 ), Color.FromArgb( 0x71, 0x50, 0x85 ), Color.FromArgb( 0x85, 0x75, 0x50 ), Color.FromArgb( 0x50, 0x85, 0x56 ),
+                Color.FromArgb( 0x50, 0x75, 0x85 ), Color.FromArgb( 0x78, 0x50, 0x85 ), Color.FromArgb( 0x83, 0x85, 0x50 ), Color.FromArgb( 0x60, 0x50, 0x85 ),
+                Color.FromArgb( 0x85, 0x6A, 0x50 ), Color.FromArgb( 0x85, 0x50, 0x5A ), Color.FromArgb( 0x50, 0x85, 0x85 ), Color.FromArgb( 0x6A, 0x50, 0x85 ),
+
+                Color.FromArgb( 0x1B, 0x1B, 0xBA ), Color.FromArgb( 0xBA, 0xA3, 0x1B ), Color.FromArgb( 0xBA, 0x33, 0x1B ), Color.FromArgb( 0x1B, 0xBA, 0x8A ),
+                Color.FromArgb( 0xBA, 0x1B, 0x93 ), Color.FromArgb( 0x7E, 0x1B, 0xBA ), Color.FromArgb( 0xBA, 0x8A, 0x1B ), Color.FromArgb( 0x1B, 0xBA, 0x2F ),
+                Color.FromArgb( 0x1B, 0x8A, 0xBA ), Color.FromArgb( 0x93, 0x1B, 0xBA ), Color.FromArgb( 0xB3, 0xBA, 0x1B ), Color.FromArgb( 0x4A, 0x1B, 0xBA ),
+                Color.FromArgb( 0xBA, 0x6A, 0x1B ), Color.FromArgb( 0xBA, 0x1B, 0x3A ), Color.FromArgb( 0x1B, 0xBA, 0xBA ), Color.FromArgb( 0x6A, 0x1B, 0xBA ),
+
+                Color.FromArgb( 0x35, 0x35, 0x9F ), Color.FromArgb( 0x9F, 0x8F, 0x35 ), Color.FromArgb( 0x9F, 0x45, 0x35 ), Color.FromArgb( 0x35, 0x9F, 0x80 ),
+                Color.FromArgb( 0x9F, 0x35, 0x85 ), Color.FromArgb( 0x78, 0x35, 0x9F ), Color.FromArgb( 0x9F, 0x80, 0x35 ), Color.FromArgb( 0x35, 0x9F, 0x43 ),
+                Color.FromArgb( 0x35, 0x80, 0x9F ), Color.FromArgb( 0x85, 0x35, 0x9F ), Color.FromArgb( 0x9A, 0x9F, 0x35 ), Color.FromArgb( 0x55, 0x35, 0x9F ),
+                Color.FromArgb( 0x9F, 0x6A, 0x35 ), Color.FromArgb( 0x9F, 0x35, 0x4A ), Color.FromArgb( 0x35, 0x9F, 0x9F ), Color.FromArgb( 0x6A, 0x35, 0x9F ) };
+
+        static readonly Color[] _foregroundColor = new Color[] { Color.Black, Color.Aquamarine, Color.Gold, Color.White };
+        static readonly char[] _b64e = new char[] {  '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                       'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+                       'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+                       'U', 'V', 'W', 'X', 'Y', 'Z',
+                       'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
+                       'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
+                       'u', 'v', 'w', 'x', 'y', 'z',
+                       '+', '/'};
+
+        int cnt = 0;
         void DisplayFormattedEntry( MulticastLogEntryTextBuilder.FormattedEntry entry, LogLevel logLevel )
         {
             ConsoleColor prevForegroundColor = System.Console.ForegroundColor;
@@ -87,12 +122,53 @@ namespace CK.Monitoring.Handlers
                 _currentMonitor = entry.MonitorId;
                 _monitorColorSwitch = !_monitorColorSwitch;
             }
-            if( _monitorColorSwitch )
+            if( _config.EnableMonitorIdColorFlag )
             {
-                System.Console.ForegroundColor = prevBackgroundColor;
-                System.Console.BackgroundColor = prevForegroundColor;
+                string monitorId = entry.MonitorId;
+                System.Console.Write( monitorId[0] );
+                for( int i = 1; i < monitorId.Length; i++ )
+                {
+                    int b64 = _b64e.IndexOf( s => s == monitorId[i] );
+                    if( b64 != -1 )
+                    {
+                        System.Console.Write( monitorId[i].ToString().Pastel( _foregroundColor[b64 / 16] ).PastelBg( _colors[b64] ) );
+                    }
+                    else
+                    {
+                        System.Console.Write( monitorId[i].ToString() );
+                    }
+                }
             }
-            System.Console.Write( entry.MonitorId );
+            else if( _config.Cocorico )
+            {
+                if( cnt % 3 == 0 )
+                {
+                    prevBackgroundColor = ConsoleColor.Blue;
+                    System.Console.BackgroundColor = ConsoleColor.Blue;
+                }
+                else if( cnt % 3 == 2 )
+                {
+                    prevBackgroundColor = ConsoleColor.Red;
+                    System.Console.BackgroundColor = ConsoleColor.Red;
+                }
+                else
+                {
+                    prevBackgroundColor = ConsoleColor.White;
+                    System.Console.BackgroundColor = ConsoleColor.White;
+                }
+                cnt++;
+            }
+            else
+            {
+                if( _monitorColorSwitch )
+                {
+                    System.Console.ForegroundColor = prevBackgroundColor;
+                    System.Console.BackgroundColor = prevForegroundColor;
+                }
+                System.Console.Write( entry.MonitorId );
+            }
+
+
             ConsoleSetColor();
             System.Console.Write( " " + entry.LogLevel + " " );
             ConsoleResetColor();

--- a/CK.Monitoring/Handlers/Console.cs
+++ b/CK.Monitoring/Handlers/Console.cs
@@ -139,25 +139,6 @@ namespace CK.Monitoring.Handlers
                     }
                 }
             }
-            else if( _config.Cocorico )
-            {
-                if( cnt % 3 == 0 )
-                {
-                    prevBackgroundColor = ConsoleColor.Blue;
-                    System.Console.BackgroundColor = ConsoleColor.Blue;
-                }
-                else if( cnt % 3 == 2 )
-                {
-                    prevBackgroundColor = ConsoleColor.Red;
-                    System.Console.BackgroundColor = ConsoleColor.Red;
-                }
-                else
-                {
-                    prevBackgroundColor = ConsoleColor.White;
-                    System.Console.BackgroundColor = ConsoleColor.White;
-                }
-                cnt++;
-            }
             else
             {
                 if( _monitorColorSwitch )

--- a/CK.Monitoring/Handlers/ConsoleConfiguration.cs
+++ b/CK.Monitoring/Handlers/ConsoleConfiguration.cs
@@ -16,6 +16,16 @@ namespace CK.Monitoring.Handlers
         public ConsoleColor BackgroundColor { get; set; }
 
         /// <summary>
+        /// Enable unique color per monitor id
+        /// </summary>
+        public bool EnableMonitorIdColorFlag { get; set; }
+
+        /// <summary>
+        /// Does... things...
+        /// </summary>
+        public bool Cocorico { get; set; }
+
+        /// <summary>
         /// Time format string used to display the DateTime before each logged line.
         /// If not set, the format used will be "yyyy-MM-dd HH\hmm.ss.fff"
         /// </summary>
@@ -38,7 +48,9 @@ namespace CK.Monitoring.Handlers
             {
                 BackgroundColor = BackgroundColor,
                 DateFormat = DateFormat,
-                UseDeltaTime = UseDeltaTime
+                UseDeltaTime = UseDeltaTime,
+                EnableMonitorIdColorFlag = EnableMonitorIdColorFlag,
+                Cocorico = Cocorico
             };
         }
     }

--- a/CK.Monitoring/Handlers/ConsoleConfiguration.cs
+++ b/CK.Monitoring/Handlers/ConsoleConfiguration.cs
@@ -16,14 +16,9 @@ namespace CK.Monitoring.Handlers
         public ConsoleColor BackgroundColor { get; set; }
 
         /// <summary>
-        /// Enable unique color per monitor id
+        /// Default to false, enable unique color per monitor id.
         /// </summary>
         public bool EnableMonitorIdColorFlag { get; set; }
-
-        /// <summary>
-        /// Does... things...
-        /// </summary>
-        public bool Cocorico { get; set; }
 
         /// <summary>
         /// Time format string used to display the DateTime before each logged line.

--- a/CK.Monitoring/MulticastLogEntryTextBuilder.cs
+++ b/CK.Monitoring/MulticastLogEntryTextBuilder.cs
@@ -195,7 +195,7 @@ namespace CK.Monitoring
                 }
                 monitorId = B64ConvertInt( _monitorNames.Count );
                 _monitorNames.Add( logEntry.MonitorId, monitorId );
-                firstLine = new FormattedEntry( 'i', indentationPrefix, monitorId, formattedDate, $"Monitor: ~{logEntry.MonitorId.ToString()}. {_monitorResetLog}" );
+                firstLine = new FormattedEntry( 'i', indentationPrefix, monitorId, formattedDate, $"Monitor: ~{logEntry.MonitorId}. {_monitorResetLog}" );
             }
             else
             {


### PR DESCRIPTION
Added an EnableMonitorIdColorFlag option to display a different color for each MonitorId : 
![image](https://user-images.githubusercontent.com/18743295/86981745-bfc00680-c187-11ea-9a8b-551933da7df9.png)

Added an Cocorico option, simple easter egg:
![image](https://user-images.githubusercontent.com/18743295/86981261-5be90e00-c186-11ea-9e73-5c4e57f41637.png)

The extra colors require ANSI and is enabled on windows by calling a windows dll.
This is handled by a single file taken from https://github.com/silkfire/Pastel
It also add an extension method on the string to easily add the ANSI color on any string.

I don't think it would cause any issue, it's an opt-in feature anyway. The only, important, question, is, should we enable the Cocorico option on the 14 july.