### PR TITLE
Fix MS.Extensions.Logging adapter not being loaded

### DIFF
--- a/CK.Monitoring.Hosting/GrandOutputConfigurator.cs
+++ b/CK.Monitoring.Hosting/GrandOutputConfigurator.cs
@@ -69,7 +69,7 @@ sealed class GrandOutputConfigurator
             LogFile.RootLogPath = Path.GetFullPath( Path.Combine( builder.Environment.ContentRootPath, section["LogPath"] ?? "Logs" ) );
         }
         ApplyDynamicConfiguration( initialConfigMustWaitForApplication: true );
-        builder.Services.AddSingleton( _loggerProvider );
+        builder.Services.AddSingleton<ILoggerProvider>( _loggerProvider );
 
         if( !isDefaultGrandOutput )
         {
@@ -195,7 +195,7 @@ sealed class GrandOutputConfigurator
                     {
                         ActivityMonitor.DefaultFilter = defaultFilter;
                     }
-                    // If the filter is invalid (a None appears), keep the default Trace. 
+                    // If the filter is invalid (a None appears), keep the default Trace.
                 }
                 else
                 {

--- a/Tests/CK.Monitoring.Hosting.Tests/HostApplicationBuilderTests.cs
+++ b/Tests/CK.Monitoring.Hosting.Tests/HostApplicationBuilderTests.cs
@@ -10,6 +10,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace CK.Monitoring.Hosting.Tests;
 
@@ -302,4 +304,32 @@ public partial class HostApplicationBuilderTests
         }
     }
 
+    [Test]
+    public async Task MS_Logging_Adapter_works_Async()
+    {
+        // Disposes current GrandOutput.Default if any.
+        var d = GrandOutput.Default;
+        if( d != null ) await d.DisposeAsync();
+
+        DemoSinkHandler.Reset();
+
+        var config = new DynamicConfigurationSource();
+        config["CK-Monitoring:GrandOutput:Handlers:CK.Monitoring.Hosting.Tests.DemoSinkHandler, CK.Monitoring.Hosting.Tests"] = "true";
+        config["CK-Monitoring:GrandOutput:HandleDotNetLogs"] = "true";
+        config["CK-Monitoring:GrandOutput:MinimalFilter"] = "Debug";
+
+        var builder = Host.CreateEmptyApplicationBuilder( new HostApplicationBuilderSettings { DisableDefaults = true } );
+        builder.Configuration.Sources.Add( config );
+
+        builder.UseCKMonitoring();
+        builder.Services.AddLogging();
+        var host = builder.Build();
+        System.Threading.Thread.Sleep( 200 );
+
+        var logger = host.Services.GetRequiredService<ILogger<HostApplicationBuilderTests>>();
+        logger.LogInformation( "Hello world (MS.Extensions.Logging)" );
+
+        var texts = DemoSinkHandler.LogEvents.OrderBy( e => e.LogTime ).Select( e => e.Text ).ToArray();
+        texts.Should().Contain( "[CK.Monitoring.Hosting.Tests.HostApplicationBuilderTests] Hello world (MS.Extensions.Logging)" );
+    }
 }


### PR DESCRIPTION
Fixes Monitoring not receiving logs from code and third-party libraries using MS.Extensions.Logging.

The GrandOutputLoggerAdapterProvider was previously registered with MS.Extensions.Logging via `ILoggingBuilder.AddProvider( provider );`.
The refactoring of GrandOutputConfigurationInitializer into GrandOutputConfigurator as part of the net8.0 upgrade caused the GrandOutputLoggerAdapterProvider to be added as part of DI instead, via `IServiceCollection.AddSingleton( provider );`, but not as `ILoggerProvider`. When MS.Extensions.Logging is looking for ILoggerProviders, it would not find the GrandOutputLoggerAdapterProvider. This is normal behavior for providers/factories stored in the MS DI, as well as other shared utility types (like the IHostedService, which is used below).

Also added a (dumb) unit test just to check if surface logging using MS.Extensions.Logging works.